### PR TITLE
Allow title and legend to be optional

### DIFF
--- a/lib/prawn/charts/base.rb
+++ b/lib/prawn/charts/base.rb
@@ -98,8 +98,8 @@ module Prawn
         with_color do
           bounding_box at, width: width, height: height do
 
-            with_larger_font { draw_title }
-            draw_legend
+            with_larger_font { draw_title } if config[:title].present?
+            draw_legend if config[:legend].present?
 
             bounding_box(chart_at, width: chart_width, height: chart_height) do
 


### PR DESCRIPTION
Allows setting `title` or `legend` to `false` in the config hash to prevent those from being output on the graph.
